### PR TITLE
Update package to require iOS 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "NeumorphismTab",
+    platforms: [
+        .iOS(.v11)
+    ],
     products: [
         .library(
             name: "NeumorphismTab",


### PR DESCRIPTION
When importing into a project using GUI based SPM with Xcode 11, the library will not compile because it depends on version-specific iOS features without specifying the iOS version. This simply adds the iOS 11 requirement, fixing the issue.